### PR TITLE
Fix hamburger menu visibility

### DIFF
--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -112,8 +112,8 @@ export function Header() {
               <ThemeToggle />
             </motion.div>
             
-            {/* ハンバーガーメニューボタン（タブレット・モバイルのみ表示） */}
-            <div className="block sm:block md:block lg:hidden xl:hidden 2xl:hidden">
+            {/* ハンバーガーメニューボタン（PC では非表示） */}
+            <div className="lg:hidden">
               <motion.div
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
@@ -144,7 +144,7 @@ export function Header() {
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.3 }}
-            className="block sm:block md:block lg:hidden xl:hidden 2xl:hidden"
+            className="lg:hidden"
           >
             <div className="px-2 pt-2 pb-3 flex flex-wrap gap-2 bg-background/95 backdrop-blur-md rounded-lg mt-2 border">
               {navItems.map((item) => (


### PR DESCRIPTION
## Summary
- hide hamburger menu on desktop sizes

## Testing
- `npm run lint` *(fails: Next.js lint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6840f5381d38832398ce0c1cc32a71d3